### PR TITLE
Fixes #17, #22, and maybe #12

### DIFF
--- a/src/main/java/electroblob/wizardry/client/GuiWizardHandbook.java
+++ b/src/main/java/electroblob/wizardry/client/GuiWizardHandbook.java
@@ -182,7 +182,7 @@ public class GuiWizardHandbook extends GuiScreen {
 		RenderHelper.enableGUIStandardItemLighting();
 		GlStateManager.disableLighting();
 		GlStateManager.enableRescaleNormal();
-		GL11.glEnable(GL11.GL_COLOR_MATERIAL);
+		GlStateManager.enableColorMaterial();
 		GlStateManager.enableLighting();
 		itemRender.zLevel = 100.0F;
 
@@ -204,7 +204,7 @@ public class GuiWizardHandbook extends GuiScreen {
 
 		GlStateManager.popMatrix();
 		GlStateManager.enableLighting();
-		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		GlStateManager.enableDepth();
 		RenderHelper.enableStandardItemLighting();
 
 	}
@@ -219,7 +219,7 @@ public class GuiWizardHandbook extends GuiScreen {
 		RenderHelper.enableGUIStandardItemLighting();
 		GlStateManager.disableLighting();
 		GlStateManager.enableRescaleNormal();
-		GL11.glEnable(GL11.GL_COLOR_MATERIAL);
+		GlStateManager.enableColorMaterial();
 		itemRender.zLevel = 0.0F;
 		GlStateManager.disableLighting();
 
@@ -239,7 +239,7 @@ public class GuiWizardHandbook extends GuiScreen {
 
 		GlStateManager.popMatrix();
 		GlStateManager.enableLighting();
-		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		GlStateManager.enableDepth();
 		RenderHelper.enableStandardItemLighting();
 
 	}

--- a/src/main/java/electroblob/wizardry/client/WizardryClientEventHandler.java
+++ b/src/main/java/electroblob/wizardry/client/WizardryClientEventHandler.java
@@ -1,7 +1,5 @@
 package electroblob.wizardry.client;
 
-import java.lang.reflect.Field;
-
 import org.lwjgl.opengl.GL11;
 
 import electroblob.wizardry.WizardData;
@@ -21,7 +19,6 @@ import electroblob.wizardry.util.WandHelper;
 import electroblob.wizardry.util.WizardryUtilities;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiMerchant;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
@@ -50,7 +47,6 @@ import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -73,12 +69,6 @@ public final class WizardryClientEventHandler {
 	private static final ResourceLocation pointerTexture = new ResourceLocation(Wizardry.MODID, "textures/entity/pointer.png");
 	private static final ResourceLocation targetPointerTexture = new ResourceLocation(Wizardry.MODID, "textures/entity/target_pointer.png");
 
-	private static final Field ITEM_RENDERER;
-
-	static {
-		ITEM_RENDERER = ReflectionHelper.findField(GuiScreen.class, "itemRender", "field_146296_j");
-	}
-	
 	@SubscribeEvent
 	public static void onTextureStitchEvent(TextureStitchEvent.Pre event){
 		event.getMap().registerSprite(ContainerArcaneWorkbench.EMPTY_SLOT_CRYSTAL);
@@ -164,36 +154,30 @@ public final class WizardryClientEventHandler {
 	}
 	
 	private static void renderItemAndTooltip(GuiContainer gui, ItemStack stack, int x, int y, int mouseX, int mouseY, boolean tooltip){
-		
-		try {
-			
-			RenderItem renderItem = (RenderItem)ITEM_RENDERER.get(gui);
-			GlStateManager.pushMatrix();
-			RenderHelper.enableGUIStandardItemLighting();
-			GlStateManager.disableLighting();
-			GlStateManager.enableRescaleNormal();
-			GL11.glEnable(GL11.GL_COLOR_MATERIAL);
-			GlStateManager.enableLighting();
-			renderItem.zLevel = 100.0F;
-			
-			if(!stack.isEmpty()){
-				renderItem.renderItemAndEffectIntoGUI(stack, x, y);
-				renderItem.renderItemOverlays(Minecraft.getMinecraft().fontRenderer, stack, x, y);
-				
-				if(tooltip){
-					gui.drawHoveringText(gui.getItemToolTip(stack), mouseX + gui.getXSize()/2 - gui.width/2,
-							mouseY + gui.getYSize()/2 - gui.height/2);
-				}
-			}
 
-			GlStateManager.popMatrix();
-			GlStateManager.enableLighting();
-			GL11.glEnable(GL11.GL_DEPTH_TEST);
-			RenderHelper.enableStandardItemLighting();
-			
-		} catch (Exception e){
-			e.printStackTrace();
+		RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
+		GlStateManager.pushMatrix();
+		RenderHelper.enableGUIStandardItemLighting();
+		GlStateManager.disableLighting();
+		GlStateManager.enableRescaleNormal();
+		GlStateManager.enableColorMaterial();
+		GlStateManager.enableLighting();
+		renderItem.zLevel = 100.0F;
+
+		if(!stack.isEmpty()){
+			renderItem.renderItemAndEffectIntoGUI(stack, x, y);
+			renderItem.renderItemOverlays(Minecraft.getMinecraft().fontRenderer, stack, x, y);
+
+			if(tooltip){
+				gui.drawHoveringText(gui.getItemToolTip(stack), mouseX + gui.getXSize()/2 - gui.width/2,
+						mouseY + gui.getYSize()/2 - gui.height/2);
+			}
 		}
+
+		GlStateManager.popMatrix();
+		GlStateManager.enableLighting();
+		GlStateManager.enableDepth();
+		RenderHelper.enableStandardItemLighting();
 	}
 
 	// Third person
@@ -241,7 +225,7 @@ public final class WizardryClientEventHandler {
 			GlStateManager.disableLighting();
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240f, 240f);
 			// Disabling depth test allows it to be seen through everything.
-			GL11.glDisable(GL11.GL_DEPTH_TEST);
+			GlStateManager.disableDepth();
 			GlStateManager.color(1, 1, 1, 1);
 
 			GlStateManager.translate(event.getX(), event.getY() + event.getEntity().height + 0.5, event.getZ());
@@ -265,7 +249,7 @@ public final class WizardryClientEventHandler {
 
 			GlStateManager.enableCull();
 			GlStateManager.enableLighting();
-			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GlStateManager.enableDepth();
 
 			GlStateManager.popMatrix();
 		}
@@ -282,7 +266,7 @@ public final class WizardryClientEventHandler {
 			GlStateManager.disableLighting();
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240f, 240f);
 			// Disabling depth test allows it to be seen through everything.
-			GL11.glDisable(GL11.GL_DEPTH_TEST);
+			GlStateManager.disableDepth();
 			GlStateManager.color(1, 1, 1, 1);
 
 			GlStateManager.translate(event.getX(), event.getY() + event.getEntity().height + 0.5, event.getZ());
@@ -306,7 +290,7 @@ public final class WizardryClientEventHandler {
 
 			GlStateManager.enableCull();
 			GlStateManager.enableLighting();
-			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GlStateManager.enableDepth();
 
 			GlStateManager.popMatrix();
 		}
@@ -327,7 +311,7 @@ public final class WizardryClientEventHandler {
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240f, 240f);
 			GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 			// Disabling depth test allows it to be seen through everything.
-			GL11.glDisable(GL11.GL_DEPTH_TEST);
+			GlStateManager.disableDepth();
 
 			GlStateManager.translate(event.getX(), event.getY() + event.getEntity().height * 0.6, event.getZ());
 
@@ -351,7 +335,7 @@ public final class WizardryClientEventHandler {
 			GlStateManager.enableCull();
 			GlStateManager.disableBlend();
 			GlStateManager.enableLighting();
-			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GlStateManager.enableDepth();
 
 			GlStateManager.popMatrix();
 		}
@@ -365,8 +349,8 @@ public final class WizardryClientEventHandler {
 
 			GlStateManager.pushMatrix();
 
-			GL11.glDisable(GL11.GL_DEPTH_TEST);
-			GL11.glDepthMask(false);
+			GlStateManager.disableDepth();
+			GlStateManager.depthMask(false);
 			OpenGlHelper.glBlendFunc(770, 771, 1, 0);
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			GlStateManager.disableAlpha();
@@ -383,8 +367,8 @@ public final class WizardryClientEventHandler {
 			buffer.pos(0.0D, 0.0D, -90.0D).tex(0.0D, 0.0D).endVertex();
 			tessellator.draw();
 
-			GL11.glDepthMask(true);
-			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GlStateManager.depthMask(true);
+			GlStateManager.enableDepth();
 			GlStateManager.enableAlpha();
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 
@@ -395,8 +379,8 @@ public final class WizardryClientEventHandler {
 
 			GlStateManager.pushMatrix();
 
-			GL11.glDisable(GL11.GL_DEPTH_TEST);
-			GL11.glDepthMask(false);
+			GlStateManager.disableDepth();
+			GlStateManager.depthMask(false);
 			OpenGlHelper.glBlendFunc(770, 771, 1, 0);
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			GlStateManager.disableAlpha();
@@ -413,8 +397,8 @@ public final class WizardryClientEventHandler {
 			buffer.pos(0.0D, 0.0D, -90.0D).tex(0.0D, 0.0D).endVertex();
 
 			tessellator.draw();
-			GL11.glDepthMask(true);
-			GL11.glEnable(GL11.GL_DEPTH_TEST);
+			GlStateManager.depthMask(true);
+			GlStateManager.enableDepth();
 			GlStateManager.enableAlpha();
 			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 

--- a/src/main/java/electroblob/wizardry/client/model/ModelWizardArmour.java
+++ b/src/main/java/electroblob/wizardry/client/model/ModelWizardArmour.java
@@ -1,10 +1,9 @@
 package electroblob.wizardry.client.model;
 
-import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.entity.Entity;
 
-public class ModelWizardArmour extends ModelBiped {
+public class ModelWizardArmour extends ModelWtfMojang {
 	ModelRenderer Shape1;
 	ModelRenderer Shape2;
 	ModelRenderer Shape3;

--- a/src/main/java/electroblob/wizardry/client/model/ModelWtfMojang.java
+++ b/src/main/java/electroblob/wizardry/client/model/ModelWtfMojang.java
@@ -1,0 +1,44 @@
+package electroblob.wizardry.client.model;
+
+import net.minecraft.client.model.ModelBiped;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityArmorStand;
+
+public class ModelWtfMojang extends ModelBiped {
+
+	public ModelWtfMojang(float modelSize, float rotationYOffset, int textureWidth, int textureHeight) {
+		super(modelSize, rotationYOffset, textureWidth, textureHeight);
+	}
+
+	@Override
+	public void setRotationAngles(float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch, float scaleFactor, Entity entityIn) {
+		// [VanillaCopy] ModelArmorStandArmor
+		// this prevents helmets from always facing south, and the armor "breathing" on the stand
+		if (entityIn instanceof EntityArmorStand) {
+			EntityArmorStand entityarmorstand = (EntityArmorStand) entityIn;
+			this.bipedHead.rotateAngleX = 0.017453292F * entityarmorstand.getHeadRotation().getX();
+			this.bipedHead.rotateAngleY = 0.017453292F * entityarmorstand.getHeadRotation().getY();
+			this.bipedHead.rotateAngleZ = 0.017453292F * entityarmorstand.getHeadRotation().getZ();
+			this.bipedHead.setRotationPoint(0.0F, 1.0F, 0.0F);
+			this.bipedBody.rotateAngleX = 0.017453292F * entityarmorstand.getBodyRotation().getX();
+			this.bipedBody.rotateAngleY = 0.017453292F * entityarmorstand.getBodyRotation().getY();
+			this.bipedBody.rotateAngleZ = 0.017453292F * entityarmorstand.getBodyRotation().getZ();
+			this.bipedLeftArm.rotateAngleX = 0.017453292F * entityarmorstand.getLeftArmRotation().getX();
+			this.bipedLeftArm.rotateAngleY = 0.017453292F * entityarmorstand.getLeftArmRotation().getY();
+			this.bipedLeftArm.rotateAngleZ = 0.017453292F * entityarmorstand.getLeftArmRotation().getZ();
+			this.bipedRightArm.rotateAngleX = 0.017453292F * entityarmorstand.getRightArmRotation().getX();
+			this.bipedRightArm.rotateAngleY = 0.017453292F * entityarmorstand.getRightArmRotation().getY();
+			this.bipedRightArm.rotateAngleZ = 0.017453292F * entityarmorstand.getRightArmRotation().getZ();
+			this.bipedLeftLeg.rotateAngleX = 0.017453292F * entityarmorstand.getLeftLegRotation().getX();
+			this.bipedLeftLeg.rotateAngleY = 0.017453292F * entityarmorstand.getLeftLegRotation().getY();
+			this.bipedLeftLeg.rotateAngleZ = 0.017453292F * entityarmorstand.getLeftLegRotation().getZ();
+			this.bipedLeftLeg.setRotationPoint(1.9F, 11.0F, 0.0F);
+			this.bipedRightLeg.rotateAngleX = 0.017453292F * entityarmorstand.getRightLegRotation().getX();
+			this.bipedRightLeg.rotateAngleY = 0.017453292F * entityarmorstand.getRightLegRotation().getY();
+			this.bipedRightLeg.rotateAngleZ = 0.017453292F * entityarmorstand.getRightLegRotation().getZ();
+			this.bipedRightLeg.setRotationPoint(-1.9F, 11.0F, 0.0F);
+			copyModelAngles(this.bipedHead, this.bipedHeadwear);
+		} else super.setRotationAngles(limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor, entityIn);
+	}
+
+}

--- a/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
+++ b/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
@@ -189,15 +189,14 @@ public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 
 	@Override
 	public void damageArmor(EntityLivingBase entity, ItemStack stack, DamageSource source, int damage, int slot){
-		if(stack.getItemDamage() < stack.getMaxDamage()){
-			if(stack.getItemDamage() + damage > stack.getMaxDamage()){
-				// Note for reference: this is the method to use, despite how it sounds attemptDamageItem() is called
-				// by this one, not the other way round.
-				stack.damageItem(stack.getMaxDamage() - stack.getItemDamage(), entity);
-			}else{
-				stack.damageItem(damage, entity);
-			}
-		}
+		stack.damageItem(damage, entity);
+	}
+
+	// Fixes wizard armor breaking by disallowing setting damage above the max, since damageArmor is not always called.
+	@Override
+	public void setDamage(ItemStack stack, int damage) {
+		if(damage <= stack.getMaxDamage()) super.setDamage(stack, damage);
+		else super.setDamage(stack, stack.getMaxDamage());
 	}
 
 	/**

--- a/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
+++ b/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
@@ -180,29 +180,29 @@ public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 		}
 	}
 
+	/*
+	 * Doesn't actually need to do anything, all values are handled in getAttibuteModifiers below.  
+	 * Returning > 0 in this method will cause it to be added to the defense value below.
+	 */
 	@Override
 	public int getArmorDisplay(EntityPlayer player, ItemStack armor, int slotIndex){
-
-		EntityEquipmentSlot slot = getArmorSlotFromIndex(slotIndex);
-
-		if(armor.getItemDamage() < armor.getMaxDamage()){
-			if(armor.hasTagCompound() && armor.getTagCompound().getBoolean("legendary")){
-				// Legendary armour gives full 10 shields, like diamond.
-				return ArmorMaterial.DIAMOND.getDamageReductionAmount(slot);
-			}else{
-				return reductions[slotIndex];
-			}
-		}else{
-			return 0;
-		}
+		return 0;
 	}
 	
+	/*
+	 * Properly handles the defense value of the armor.  This method is responisble for the tooltip on top of
+	 * the armor value.  It is also what handles armor toughness, but the wizard armor had a value of 0 for that.
+	 */
 	@Override
 	public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack) {
 		Multimap<String, AttributeModifier> map = HashMultimap.create();
-		if(stack.getItemDamage() < stack.getMaxDamage() && this.armorType == slot) 
+		if(stack.getItemDamage() < stack.getMaxDamage() && this.armorType == slot) {
+			int defense = reductions[slot.getIndex()];
+			if(stack.hasTagCompound() && stack.getTagCompound().getBoolean("legendary")) 
+				defense = ArmorMaterial.DIAMOND.getDamageReductionAmount(slot);
 			map.put(SharedMonsterAttributes.ARMOR.getName(), new AttributeModifier(ARMOR_MODIFIERS[slot.getIndex()], 
-					"Armor modifier", reductions[slot.getIndex()], 0));
+					"Armor modifier", defense, 0));
+		}
 		return map;
 	}
 

--- a/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
+++ b/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
@@ -3,6 +3,7 @@ package electroblob.wizardry.item;
 import java.util.List;
 import java.util.UUID;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
 import electroblob.wizardry.Wizardry;
@@ -198,7 +199,7 @@ public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 	
 	@Override
 	public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack) {
-		Multimap<String, AttributeModifier> map = super.getAttributeModifiers(slot, stack);
+		Multimap<String, AttributeModifier> map = HashMultimap.create();
 		if(stack.getItemDamage() < stack.getMaxDamage() && this.armorType == slot) 
 			map.put(SharedMonsterAttributes.ARMOR.getName(), new AttributeModifier(ARMOR_MODIFIERS[slot.getIndex()], 
 					"Armor modifier", reductions[slot.getIndex()], 0));

--- a/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
+++ b/src/main/java/electroblob/wizardry/item/ItemWizardArmour.java
@@ -1,6 +1,9 @@
 package electroblob.wizardry.item;
 
 import java.util.List;
+import java.util.UUID;
+
+import com.google.common.collect.Multimap;
 
 import electroblob.wizardry.Wizardry;
 import electroblob.wizardry.constants.Constants;
@@ -8,11 +11,12 @@ import electroblob.wizardry.constants.Element;
 import electroblob.wizardry.registry.WizardryAdvancementTriggers;
 import electroblob.wizardry.registry.WizardryTabs;
 import electroblob.wizardry.spell.Petrify;
-import electroblob.wizardry.util.WizardryUtilities;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.EnumAction;
@@ -31,6 +35,11 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @Mod.EventBusSubscriber
 public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 
+	//VanillaCopy, ItemArmor has this set to private for some reason.
+    public static final UUID[] ARMOR_MODIFIERS = new UUID[] {UUID.fromString("845DB27C-C624-495F-8C9F-6020A9A58B6B"), UUID.fromString("D8499B04-0E66-4726-AB29-64469D734E0D"), UUID.fromString("9F3D476D-C118-4544-8365-64846904B48E"), UUID.fromString("2AD3F246-FEE1-4E67-B886-69FD380BB150")};
+	//Damage reduction values that used to be in WizardryItems.SILK [feet, legs, chest, head]
+    private static int[] reductions = new int[]{2, 4, 5, 2};
+	
 	public Element element;
 
 	public ItemWizardArmour(ArmorMaterial material, int renderIndex, EntityEquipmentSlot armourType, Element element){
@@ -162,7 +171,7 @@ public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 				return new ArmorProperties(0, ArmorMaterial.DIAMOND.getDamageReductionAmount(slot) / 25D,
 						armor.getMaxDamage() + 1 - armor.getItemDamage());
 			}else{
-				return new ArmorProperties(0, this.damageReduceAmount / 25D,
+				return new ArmorProperties(0, reductions[slotIndex] / 25D,
 						armor.getMaxDamage() + 1 - armor.getItemDamage());
 			}
 		}else{
@@ -180,11 +189,20 @@ public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 				// Legendary armour gives full 10 shields, like diamond.
 				return ArmorMaterial.DIAMOND.getDamageReductionAmount(slot);
 			}else{
-				return this.getArmorMaterial().getDamageReductionAmount(slot);
+				return reductions[slotIndex];
 			}
 		}else{
 			return 0;
 		}
+	}
+	
+	@Override
+	public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack) {
+		Multimap<String, AttributeModifier> map = super.getAttributeModifiers(slot, stack);
+		if(stack.getItemDamage() < stack.getMaxDamage() && this.armorType == slot) 
+			map.put(SharedMonsterAttributes.ARMOR.getName(), new AttributeModifier(ARMOR_MODIFIERS[slot.getIndex()], 
+					"Armor modifier", reductions[slot.getIndex()], 0));
+		return map;
 	}
 
 	@Override
@@ -205,16 +223,8 @@ public class ItemWizardArmour extends ItemArmor implements ISpecialArmor {
 	 * integer slot index in ISpecialArmor instead of an EntityEquipmentSlot.
 	 */
 	// NOTE: Remove in 1.12.2
-	private EntityEquipmentSlot getArmorSlotFromIndex(int slotIndex){
-		// Had to pick something to begin with.
-		EntityEquipmentSlot slot = EntityEquipmentSlot.HEAD;
-
-		for(EntityEquipmentSlot s : WizardryUtilities.ARMOUR_SLOTS){
-			if(s.getIndex() == slotIndex){
-				slot = s;
-			}
-		}
-		return slot;
+	private static EntityEquipmentSlot getArmorSlotFromIndex(int index){
+		return EntityEquipmentSlot.values()[index + 2];
 	}
 
 	@SubscribeEvent

--- a/src/main/java/electroblob/wizardry/registry/WizardryItems.java
+++ b/src/main/java/electroblob/wizardry/registry/WizardryItems.java
@@ -127,7 +127,7 @@ public final class WizardryItems {
 	public static final Item armour_upgrade = new ItemArmourUpgrade();
 
 	public static final ArmorMaterial SILK = EnumHelper.addArmorMaterial("SILK",
-			"wizardry/textures/armour/wizard_armour", 15, new int[]{2, 5, 4, 2}, 0,
+			"wizardry/textures/armour/wizard_armour", 15, new int[]{0, 0, 0, 0}, 0,
 			SoundEvents.ITEM_ARMOR_EQUIP_LEATHER, 0.0F);
 	
 	// Saw a post somewhere that said you have to put these in the init methods rather than defining them as constants.


### PR DESCRIPTION
This PR does a few things.  To begin, it removes the raw GL calls in WizardryClientEventHandler and GuiWizardHandbook, which when used, invalidate the GlStateManager by making the state inconsistent with what the state manager thinks.  This may be what causes #12.  

Second, it fixes the armor stand issue though the only known fix, by copying some model code from vanilla.  The fix certainly looks ugly, but its the only fix.  

Third, it addresses wizard armor,  which is not supposed to break and is supposed to have an armor value of 0 when out of mana (as stated in #17)  Armor code is annoying and complicated, but I think I got everything.