### PR TITLE
Make Magic Silk recipe use ore_dict for string

### DIFF
--- a/src/main/resources/assets/ebwizardry/recipes/magic_silk.json
+++ b/src/main/resources/assets/ebwizardry/recipes/magic_silk.json
@@ -7,41 +7,42 @@
     ],
     "key": {
         "x": {
-            "item": "minecraft:string"
+            "type": "forge:ore_dict",
+            "ore": "string"
         },
         "y": [
             {
-				"item": "ebwizardry:magic_crystal",
-				"data": 0
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 1
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 2
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 3
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 4
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 5
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 6
-			},
-			{
-				"item": "ebwizardry:magic_crystal",
-				"data": 7
-			}
+                "item": "ebwizardry:magic_crystal",
+                "data": 0
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 1
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 2
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 3
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 4
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 5
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 6
+            },
+            {
+                "item": "ebwizardry:magic_crystal",
+                "data": 7
+            }
         ]
     },
     "result": {

--- a/src/main/resources/assets/ebwizardry/recipes/magic_silk.json
+++ b/src/main/resources/assets/ebwizardry/recipes/magic_silk.json
@@ -12,37 +12,37 @@
         },
         "y": [
             {
-                "item": "ebwizardry:magic_crystal",
-                "data": 0
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 1
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 2
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 3
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 4
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 5
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 6
-            },
-            {
-                "item": "ebwizardry:magic_crystal",
-                "data": 7
-            }
+				"item": "ebwizardry:magic_crystal",
+				"data": 0
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 1
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 2
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 3
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 4
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 5
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 6
+			},
+			{
+				"item": "ebwizardry:magic_crystal",
+				"data": 7
+			}
         ]
     },
     "result": {


### PR DESCRIPTION
Currently, the recipe requires string to be a Vanilla string, which might cause problems in packs with different methods for obtaining strings (eg: Mystical World's Silk Thread from silkworms).

This PR makes it compatible with Ore Dictionary, so the recipe accepts any type of string.