### PR TITLE
Splitting PacketSpellProperties into batches of 100 spells. 

### DIFF
--- a/src/main/java/electroblob/wizardry/packet/PacketSpellProperties.java
+++ b/src/main/java/electroblob/wizardry/packet/PacketSpellProperties.java
@@ -20,7 +20,9 @@ public class PacketSpellProperties implements IMessageHandler<PacketSpellPropert
 		if(ctx.side.isClient()){
 
 			net.minecraft.client.Minecraft.getMinecraft().addScheduledTask(() -> {
-				for(int i=0; i<message.propertiesArray.length; i++){
+
+				int first = message.firstId;
+				for(int i = first; i <message.propertiesArray.length; i++){
 					Spell.byNetworkID(i).setPropertiesClient(message.propertiesArray[i]);
 				}
 			});
@@ -32,21 +34,24 @@ public class PacketSpellProperties implements IMessageHandler<PacketSpellPropert
 	public static class Message implements IMessage {
 
 		private SpellProperties[] propertiesArray;
-
+		private int firstId;
+		private int count;
 		// This constructor is required otherwise you'll get errors (used somewhere in fml through reflection)
 		public Message(){}
 
-		public Message(SpellProperties... properties){
+		public Message(int firstId, int count, SpellProperties... properties){
+			this.firstId = firstId;
+			this.count = count;
 			this.propertiesArray = properties;
 		}
 
 		@Override
 		public void fromBytes(ByteBuf buf){
-
 			List<SpellProperties> propertiesList = new ArrayList<>();
-			int i = 0;
-
-			while(buf.isReadable()){
+			int i = buf.readInt();
+			count = buf.readInt();
+			firstId = i;
+			while(buf.isReadable() && i < count){
 				propertiesList.add(new SpellProperties(Spell.byNetworkID(i++), buf));
 			}
 
@@ -55,6 +60,8 @@ public class PacketSpellProperties implements IMessageHandler<PacketSpellPropert
 
 		@Override
 		public void toBytes(ByteBuf buf){
+			buf.writeInt(firstId);
+			buf.writeInt(count);
 			for(SpellProperties properties : propertiesArray) properties.write(buf);
 		}
 	}

--- a/src/main/java/electroblob/wizardry/spell/Spell.java
+++ b/src/main/java/electroblob/wizardry/spell/Spell.java
@@ -319,8 +319,24 @@ public abstract class Spell extends IForgeRegistryEntry.Impl<Spell> implements C
 		// To avoid sending extra data unnecessarily, the spell properties are sent in order of spell ID
 		List<Spell> spells = new ArrayList<>(registry.getValuesCollection());
 		spells.sort(Comparator.comparingInt(Spell::networkID));
-		WizardryPacketHandler.net.sendTo(new PacketSpellProperties.Message(spells.stream()
-				.map(s -> s.properties).toArray(SpellProperties[]::new)), player);
+
+		SpellProperties[] propertiesArray = spells.stream().map(s -> s.properties).toArray(SpellProperties[]::new);
+
+		// splitting the packet into batches of 100 spells
+		int i = 0;
+		while (i < propertiesArray.length) {
+			List<SpellProperties> propertiesList = new ArrayList<>();
+			int first = i;
+			int batchCounter = 0;
+			for (int currentIndex = i; currentIndex < propertiesArray.length && batchCounter < 100; currentIndex++) {
+				propertiesList.add(propertiesArray[currentIndex]);
+				batchCounter++;
+				i++;
+			}
+			SpellProperties[] currentArray = propertiesList.toArray(new SpellProperties[0]);
+			PacketSpellProperties.Message currentPacket = new PacketSpellProperties.Message(first, currentArray.length, currentArray);
+			WizardryPacketHandler.net.sendTo(currentPacket, player);
+		}
 	}
 
 	private static void clearProperties(){


### PR DESCRIPTION
The added count property with the check fixes world load issue with large list of spells. Still not really sure why but according to `buf.isReadable()` the packet was still having data after loading the last entry, but it was all gibberish and was trying to load those properties for `Spells.none`