### PR TITLE
Fix addon trades

### DIFF
--- a/src/main/java/electroblob/wizardry/entity/living/EntityWizard.java
+++ b/src/main/java/electroblob/wizardry/entity/living/EntityWizard.java
@@ -617,7 +617,7 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 
 	private ItemStack getRandomItemOfTier(Tier tier){
 
-		int randomiser;
+		int randomiser, i;
 
 		// All enabled spells of the given tier
 		List<Spell> spells = Spell.getSpells(new Spell.TierElementFilter(tier, null, SpellProperties.Context.TRADES));
@@ -628,19 +628,26 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 		spells.removeIf(s -> !s.isEnabled(SpellProperties.Context.BOOK));
 		specialismSpells.removeIf(s -> !s.isEnabled(SpellProperties.Context.BOOK));
 
+		Item spellBook = WizardryItems.spell_book;
+
 		// This code is sooooooo much neater with the new filter system!
 		switch(tier){
 
 		case NOVICE:
 			randomiser = rand.nextInt(5);
+
 			if(randomiser < 4 && !spells.isEmpty()){
 				if(this.getElement() != Element.MAGIC && rand.nextInt(4) > 0 && !specialismSpells.isEmpty()){
 					// This means it is more likely for spell books sold to be of the same element as the wizard if the
 					// wizard has an element.
-					return new ItemStack(WizardryItems.spell_book, 1,
-							specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
+					i = rand.nextInt(specialismSpells.size());
+					if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+					return new ItemStack(spellBook, 1,
+							specialismSpells.get(i).metadata());
 				}else{
-					return new ItemStack(WizardryItems.spell_book, 1, spells.get(rand.nextInt(spells.size())).metadata());
+					i = rand.nextInt(spells.size());
+					if(!spells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = spells.get(i).getApplicableItems()[0];
+					return new ItemStack(spellBook, 1, spells.get(i).metadata());
 				}
 			}else{
 				if(this.getElement() != Element.MAGIC && rand.nextInt(4) > 0){
@@ -659,10 +666,14 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 				if(this.getElement() != Element.MAGIC && rand.nextInt(4) > 0 && !specialismSpells.isEmpty()){
 					// This means it is more likely for spell books sold to be of the same element as the wizard if the
 					// wizard has an element.
-					return new ItemStack(WizardryItems.spell_book, 1,
+					i = rand.nextInt(specialismSpells.size());
+					if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+					return new ItemStack(spellBook, 1,
 							specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
 				}else{
-					return new ItemStack(WizardryItems.spell_book, 1, spells.get(rand.nextInt(spells.size())).metadata());
+					i = rand.nextInt(spells.size());
+					if(!spells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = spells.get(i).getApplicableItems()[0];
+					return new ItemStack(spellBook, 1, spells.get(i).metadata());
 				}
 			}else if(randomiser < 6){
 				if(this.getElement() != Element.MAGIC && rand.nextInt(4) > 0){
@@ -696,10 +707,14 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 				if(this.getElement() != Element.MAGIC && rand.nextInt(4) > 0 && !specialismSpells.isEmpty()){
 					// This means it is more likely for spell books sold to be of the same element as the wizard if the
 					// wizard has an element.
-					return new ItemStack(WizardryItems.spell_book, 1,
+					i = rand.nextInt(specialismSpells.size());
+					if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+					return new ItemStack(spellBook, 1,
 							specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
 				}else{
-					return new ItemStack(WizardryItems.spell_book, 1, spells.get(rand.nextInt(spells.size())).metadata());
+					i = rand.nextInt(spells.size());
+					if(!spells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = spells.get(i).getApplicableItems()[0];
+					return new ItemStack(spellBook, 1, spells.get(i).metadata());
 				}
 			}else if(randomiser < 6){
 				if(this.getElement() != Element.MAGIC && rand.nextInt(4) > 0){
@@ -724,7 +739,9 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 
 			if(randomiser < 5 && this.getElement() != Element.MAGIC && !specialismSpells.isEmpty()){
 				// Master spells can only be sold by a specialist in that element.
-				return new ItemStack(WizardryItems.spell_book, 1,
+				i = rand.nextInt(specialismSpells.size());
+				if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+				return new ItemStack(spellBook, 1,
 						specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
 
 			}else if(randomiser < 6){

--- a/src/main/java/electroblob/wizardry/entity/living/EntityWizard.java
+++ b/src/main/java/electroblob/wizardry/entity/living/EntityWizard.java
@@ -628,7 +628,8 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 		spells.removeIf(s -> !s.isEnabled(SpellProperties.Context.BOOK));
 		specialismSpells.removeIf(s -> !s.isEnabled(SpellProperties.Context.BOOK));
 
-		Item spellBook = WizardryItems.spell_book;
+		// Used to define spellbook
+		Item spellBook;
 
 		// This code is sooooooo much neater with the new filter system!
 		switch(tier){
@@ -641,12 +642,12 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 					// This means it is more likely for spell books sold to be of the same element as the wizard if the
 					// wizard has an element.
 					i = rand.nextInt(specialismSpells.size());
-					if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+					spellBook = getApplicableSpellbook(specialismSpells.get(i));
 					return new ItemStack(spellBook, 1,
 							specialismSpells.get(i).metadata());
 				}else{
 					i = rand.nextInt(spells.size());
-					if(!spells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = spells.get(i).getApplicableItems()[0];
+					spellBook = getApplicableSpellbook(spells.get(i));
 					return new ItemStack(spellBook, 1, spells.get(i).metadata());
 				}
 			}else{
@@ -667,12 +668,12 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 					// This means it is more likely for spell books sold to be of the same element as the wizard if the
 					// wizard has an element.
 					i = rand.nextInt(specialismSpells.size());
-					if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+					spellBook = getApplicableSpellbook(specialismSpells.get(i));
 					return new ItemStack(spellBook, 1,
 							specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
 				}else{
 					i = rand.nextInt(spells.size());
-					if(!spells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = spells.get(i).getApplicableItems()[0];
+					spellBook = getApplicableSpellbook(spells.get(i));
 					return new ItemStack(spellBook, 1, spells.get(i).metadata());
 				}
 			}else if(randomiser < 6){
@@ -708,12 +709,12 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 					// This means it is more likely for spell books sold to be of the same element as the wizard if the
 					// wizard has an element.
 					i = rand.nextInt(specialismSpells.size());
-					if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+					spellBook = getApplicableSpellbook(specialismSpells.get(i));
 					return new ItemStack(spellBook, 1,
 							specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
 				}else{
 					i = rand.nextInt(spells.size());
-					if(!spells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = spells.get(i).getApplicableItems()[0];
+					spellBook = getApplicableSpellbook(spells.get(i));
 					return new ItemStack(spellBook, 1, spells.get(i).metadata());
 				}
 			}else if(randomiser < 6){
@@ -740,7 +741,7 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 			if(randomiser < 5 && this.getElement() != Element.MAGIC && !specialismSpells.isEmpty()){
 				// Master spells can only be sold by a specialist in that element.
 				i = rand.nextInt(specialismSpells.size());
-				if(!specialismSpells.get(i).applicableForItem(WizardryItems.spell_book)) spellBook = specialismSpells.get(i).getApplicableItems()[0];
+				spellBook = getApplicableSpellbook(specialismSpells.get(i));
 				return new ItemStack(spellBook, 1,
 						specialismSpells.get(rand.nextInt(specialismSpells.size())).metadata());
 
@@ -757,6 +758,17 @@ public class EntityWizard extends EntityCreature implements INpc, IMerchant, ISp
 		}
 
 		return new ItemStack(Blocks.STONE);
+	}
+
+	/** Used to get Applicable spellbook automatically. If there is no custom book for it, then it sets it to default one.
+	 *  **/
+	private Item getApplicableSpellbook(Spell spell){
+		Collection<Item> values = ForgeRegistries.ITEMS.getValuesCollection();
+		List<Item> book = values.stream().filter(spellBook ->
+				spellBook instanceof ItemSpellBook && spell.applicableForItem(spellBook)).collect(Collectors.toList());
+		if(!book.isEmpty())
+			return book.get(0);
+		return WizardryItems.spell_book;
 	}
 
 	@Override

--- a/src/main/java/electroblob/wizardry/spell/Spell.java
+++ b/src/main/java/electroblob/wizardry/spell/Spell.java
@@ -921,6 +921,12 @@ public abstract class Spell extends IForgeRegistryEntry.Impl<Spell> implements C
 	public boolean applicableForItem(Item item){
 		return Arrays.asList(applicableItems).contains(item);
 	}
+	
+	/** Returns Items spell applicable to. Used in {@link EntityWizard#getRandomItemOfTier(Tier)}
+	 * First(0) element is {@link ItemSpellBook()}, when the Second one (1) is {@link ItemScroll ()} **/
+	public Item[] getApplicableItems(){
+		return new Item[]{WizardryItems.spell_book, WizardryItems.scroll};
+	}
 
 	/**
 	 * Sets which items this spell can appear on (these default to the regular spell book and scroll).

--- a/src/main/java/electroblob/wizardry/spell/Spell.java
+++ b/src/main/java/electroblob/wizardry/spell/Spell.java
@@ -921,12 +921,6 @@ public abstract class Spell extends IForgeRegistryEntry.Impl<Spell> implements C
 	public boolean applicableForItem(Item item){
 		return Arrays.asList(applicableItems).contains(item);
 	}
-	
-	/** Returns Items spell applicable to. Used in {@link EntityWizard#getRandomItemOfTier(Tier)}
-	 * First(0) element is {@link ItemSpellBook()}, when the Second one (1) is {@link ItemScroll ()} **/
-	public Item[] getApplicableItems(){
-		return new Item[]{WizardryItems.spell_book, WizardryItems.scroll};
-	}
 
 	/**
 	 * Sets which items this spell can appear on (these default to the regular spell book and scroll).


### PR DESCRIPTION
First i made change for Spell class, to have a method, which when overwritten with isItemApplicable() method both will make possible to EntityWizard's to trade the add-on spellbook items

This means i also overwritten EntityWizard's getRandomItemOfTier() to make this possible

Sorry for bad english, still have a headache.. ugh.. well, that's it!

