### PR TITLE
Changes to ItemWand Cooldowns Decrement

### DIFF
--- a/src/main/java/electroblob/wizardry/item/ItemWand.java
+++ b/src/main/java/electroblob/wizardry/item/ItemWand.java
@@ -227,8 +227,8 @@ public class ItemWand extends Item implements IWorkbenchItem, ISpellCastingItem,
 
 	@Override
 	public void onUpdate(ItemStack stack, World world, Entity entity, int slot, boolean isHeld){
-
-		WandHelper.decrementCooldowns(stack);
+		
+		if(isHeld) WandHelper.decrementCooldowns(stack);
 
 		// Decrements wand damage (increases mana) every 1.5 seconds if it has a condenser upgrade
 		if(!world.isRemote && !this.isManaFull(stack) && world.getTotalWorldTime() % Constants.CONDENSER_TICK_INTERVAL == 0){


### PR DESCRIPTION
Those changes made to prevent players comfy use more then one wand to cast multiple spells at time. They even may use some time and have 9 wands casting
spells one by one without stop...

This makes so, that they'll require to held wand they decrease cooldown of...

Other solution is to somehow half the Cooldown decrement while wand is not held, this is not fully solves it, but helps in solving

It's not the best solution for sure