### PR TITLE
Update to sounds.json (Mirage spell)

### DIFF
--- a/src/main/resources/assets/ebwizardry/sounds.json
+++ b/src/main/resources/assets/ebwizardry/sounds.json
@@ -363,6 +363,7 @@
 	"spell.zombie_apocalypse.start": 	{"category": "spells", "sounds": ["ebwizardry:dark_aura_start"]},
 	"spell.zombie_apocalypse.loop": 	{"category": "spells", "sounds": ["ebwizardry:dark_aura_loop"]},
 	"spell.zombie_apocalypse.end": 		{"category": "spells", "sounds": ["ebwizardry:dark_aura_end"]},
+	"spell.mirage": 				{"category": "spells", "sounds": ["ebwizardry:buff"]},
 
 	"forfeit.burn_self":				{"category": "spells", "sounds": ["fire/ignite"]},
 	"forfeit.fireball":					{"category": "spells", "sounds": ["mob/ghast/fireball4"]},


### PR DESCRIPTION
Because of "[Client thread/WARN]: Missing sound for event: ebwizardry:spell.mirage" in latest.log i found that Mirage spell has no effect, even if it's registered. That's why with this request i add it to sounds.json.