### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip


### PR DESCRIPTION
Maven central plugin library closes support for http protocol, resulting in error 501, upgrade gradle-2.0 to gradle-2.14 to solve this problem