### PR TITLE
1.12.2 fixes

### DIFF
--- a/src/main/java/electroblob/wizardry/item/ItemScroll.java
+++ b/src/main/java/electroblob/wizardry/item/ItemScroll.java
@@ -160,12 +160,21 @@ public class ItemScroll extends Item implements ISpellCastingItem, IWorkbenchIte
 
 			Spell spell = Spell.byMetadata(stack.getItemDamage());
 			// By default, scrolls have no modifiers - but with the event system, they could be added.
-			SpellModifiers modifiers = new SpellModifiers();
+
+			SpellModifiers modifiers;
+
+			if(WizardData.get(player) != null){
+				modifiers = WizardData.get(player).itemCastingModifiers;
+			}else{
+				modifiers = new SpellModifiers();
+			}
+
 			int castingTick = stack.getMaxItemUseDuration() - count;
 
 			// Continuous spells (these must check if they can be cast each tick since the mana changes)
 			// In theory the spell is always continuous here but just in case it isn't...
-			if(spell.isContinuous && canCast(stack, spell, player, player.getActiveHand(), castingTick, modifiers)){
+			// Do not check canCast() on tick 0 as it is already done in onItemRightClick() and will duplicated modifiers
+			if(spell.isContinuous && (castingTick == 0 || canCast(stack, spell, player, player.getActiveHand(), castingTick, modifiers))){
 				cast(stack, spell, player, player.getActiveHand(), castingTick, modifiers);
 			}else{
 				// Scrolls normally work on the max use duration so this isn't ever reached by wizardry, but if the

--- a/src/main/java/electroblob/wizardry/item/ItemScroll.java
+++ b/src/main/java/electroblob/wizardry/item/ItemScroll.java
@@ -173,7 +173,7 @@ public class ItemScroll extends Item implements ISpellCastingItem, IWorkbenchIte
 
 			// Continuous spells (these must check if they can be cast each tick since the mana changes)
 			// In theory the spell is always continuous here but just in case it isn't...
-			// Do not check canCast() on tick 0 as it is already done in onItemRightClick() and will duplicated modifiers
+			// Do not check canCast() on tick 0 as it is already done in onItemRightClick() and would duplicate modifiers
 			if(spell.isContinuous && (castingTick == 0 || canCast(stack, spell, player, player.getActiveHand(), castingTick, modifiers))){
 				cast(stack, spell, player, player.getActiveHand(), castingTick, modifiers);
 			}else{


### PR DESCRIPTION
Modifiers persist in continuous spells cast by scrolls.

Added check for tick 0 as to not reapply SpellModifier changes