### PR TITLE
fix: Fixed NPE crash for isAllied() function, causing world deadlocks

### DIFF
--- a/src/main/java/electroblob/wizardry/util/AllyDesignationSystem.java
+++ b/src/main/java/electroblob/wizardry/util/AllyDesignationSystem.java
@@ -206,6 +206,10 @@ public final class AllyDesignationSystem {
 	 * generally used to determine targets for healing or other group buffs. */
 	public static boolean isAllied(EntityLivingBase allyOf, EntityLivingBase possibleAlly){
 
+        if (allyOf == null || possibleAlly == null) {
+            return false;
+        }
+
 		// Owned entities inherit their owner's allies
 		if(allyOf instanceof IEntityOwnable){
 			Entity owner = ((IEntityOwnable)allyOf).getOwner();


### PR DESCRIPTION
- This fixes Electroblob's Wizardry - 4.3.16 - MC 1.12.2, specifically the NPE crash with the ally designation system crash. Attached is a sample crash that deadlocks a world upon approaching a sage mound (that has the arcane wall block)