### PR TITLE
Artefact Changes

### DIFF
--- a/src/main/java/electroblob/wizardry/client/WizardryClientEventHandler.java
+++ b/src/main/java/electroblob/wizardry/client/WizardryClientEventHandler.java
@@ -14,6 +14,7 @@ import electroblob.wizardry.spell.SixthSense;
 import electroblob.wizardry.spell.SlowTime;
 import electroblob.wizardry.spell.Transience;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.BufferBuilder;
@@ -21,6 +22,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityDispenser;
@@ -106,21 +108,50 @@ public final class WizardryClientEventHandler {
 		}
 	}
 
+	@SubscribeEvent
+	public static void onRenderCameraSetupEvent(EntityViewRenderEvent.CameraSetup event) {
+		EntityPlayerSP player = Minecraft.getMinecraft().player;
+		//Prevents the camera from flickering when trying to turn when paralysed
+		if (player.isPotionActive(WizardryPotions.paralysis)) {
+			WizardData data = WizardData.get(player);
+			if (data != null) {
+				event.setPitch(data.paralyzedRotationPitch);
+				event.setYaw(data.paralyzedRotationYaw + 180);
+			}
+		}
+	}
+
+/*	@SubscribeEvent
+	public static void onRenderLivingEvent(RenderLivingEvent event) {
+		if (event.getEntity() instanceof EntityPlayer) {
+			EntityPlayer player = (EntityPlayer)event.getEntity();
+			if (player.isPotionActive(WizardryPotions.paralysis) && Minecraft.getMinecraft().inGameHasFocus) {
+				WizardData data = WizardData.get(player);
+				if (data != null) {
+					player.prevRotationPitch = data.paralyzedRotationPitch;
+					player.prevRotationYaw = data.paralyzedRotationYaw;
+					player.rotationPitch = data.paralyzedRotationPitch;
+					player.rotationYaw = data.paralyzedRotationYaw;
+				}
+			}
+		}
+	}*/
+
 	// Input and Controls
 	// ===============================================================================================================
 
 	@SubscribeEvent
 	public static void onMouseEvent(MouseEvent event){
-
-		// Prevents the player looking around when paralysed
-		if(Minecraft.getMinecraft().player.isPotionActive(WizardryPotions.paralysis)
-				&& Minecraft.getMinecraft().inGameHasFocus){
-			event.setCanceled(true);
-			Minecraft.getMinecraft().player.prevRotationYaw = 0;
-			Minecraft.getMinecraft().player.prevRotationPitch = 0;
-			Minecraft.getMinecraft().player.rotationYaw = 0;
-			Minecraft.getMinecraft().player.rotationPitch = 0;
-
+		EntityPlayerSP player = Minecraft.getMinecraft().player;
+		// Prevents the player's model from looking around when paralysed
+		if(player.isPotionActive(WizardryPotions.paralysis) && Minecraft.getMinecraft().inGameHasFocus){
+			WizardData data = WizardData.get(player);
+			if (data != null) {
+				player.prevRotationPitch = data.paralyzedRotationPitch;
+				player.prevRotationYaw = data.paralyzedRotationYaw;
+				player.rotationPitch = data.paralyzedRotationPitch;
+				player.rotationYaw = data.paralyzedRotationYaw;
+			}
 		}
 	}
 
@@ -161,6 +192,19 @@ public final class WizardryClientEventHandler {
 				event.setCanceled(true);
 			}
 		}
+
+		EntityPlayerSP player = Minecraft.getMinecraft().player;
+		// Prevents the player's hand from moving around when paralysed
+		if(player.isPotionActive(WizardryPotions.paralysis)){
+			WizardData data = WizardData.get(player);
+			if (data != null) {
+				player.prevRotationPitch = data.paralyzedRotationPitch;
+				player.prevRotationYaw = data.paralyzedRotationYaw;
+				player.rotationPitch = data.paralyzedRotationPitch;
+				player.rotationYaw = data.paralyzedRotationYaw;
+			}
+		}
+
 	}
 
 	@SubscribeEvent

--- a/src/main/java/electroblob/wizardry/data/WizardData.java
+++ b/src/main/java/electroblob/wizardry/data/WizardData.java
@@ -135,6 +135,10 @@ public class WizardData implements INBTSerializable<NBTTagCompound> {
 	/** Stores this player's y velocity from the previous tick; used for the velocity-based fall damage replacement. */
 	public double prevMotionY;
 
+	//Used to store the player's pitch and rotation when affected by the paralysis spell so they remain looking at the position during which they were paralyzed
+	public float paralyzedRotationPitch;
+	public float paralyzedRotationYaw;
+
 	public WizardData(){
 		this(null); // Nullary constructor for the registration method factory parameter
 	}

--- a/src/main/java/electroblob/wizardry/entity/construct/EntityBlackHole.java
+++ b/src/main/java/electroblob/wizardry/entity/construct/EntityBlackHole.java
@@ -137,8 +137,7 @@ public class EntityBlackHole extends EntityScaledConstruct {
 				if(this.isValidTarget(target)){
 
 					// If the target can't be moved, it isn't sucked in but is still damaged if it gets too close
-					if(!(target instanceof EntityPlayer && ((getCaster() instanceof EntityPlayer && !Wizardry.settings.playersMoveEachOther)
-							|| ItemArtefact.isArtefactActive((EntityPlayer)target, WizardryItems.amulet_anchoring)))){
+					if(EntityUtils.canEntityBeMoved(this.getCaster(), target)){
 
 						EntityUtils.undoGravity(target);
 						if(target instanceof EntityLevitatingBlock) ((EntityLevitatingBlock)target).suspend();

--- a/src/main/java/electroblob/wizardry/entity/construct/EntityTornado.java
+++ b/src/main/java/electroblob/wizardry/entity/construct/EntityTornado.java
@@ -1,9 +1,7 @@
 package electroblob.wizardry.entity.construct;
 
 import electroblob.wizardry.Wizardry;
-import electroblob.wizardry.item.ItemArtefact;
 import electroblob.wizardry.registry.Spells;
-import electroblob.wizardry.registry.WizardryItems;
 import electroblob.wizardry.registry.WizardrySounds;
 import electroblob.wizardry.spell.Spell;
 import electroblob.wizardry.spell.Tornado;
@@ -18,7 +16,6 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.MoverType;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.play.server.SPacketEntityVelocity;
@@ -79,15 +76,9 @@ public class EntityTornado extends EntityScaledConstruct {
 
 		if(!this.world.isRemote){
 
-			List<EntityLivingBase> targets = EntityUtils.getLivingWithinRadius(radius, this.posX, this.posY,
-					this.posZ, this.world);
+			List<EntityLivingBase> targets = EntityUtils.getLivingWithinRadius(radius, this.posX, this.posY, this.posZ, this.world);
 
 			for(EntityLivingBase target : targets){
-
-				if(target instanceof EntityPlayer && ((getCaster() instanceof EntityPlayer && !Wizardry.settings.playersMoveEachOther)
-						|| ItemArtefact.isArtefactActive((EntityPlayer)target, WizardryItems.amulet_anchoring))){
-					continue;
-				}
 
 				if(this.isValidTarget(target)){
 
@@ -110,13 +101,14 @@ public class EntityTornado extends EntityScaledConstruct {
 						target.attackEntityFrom(DamageSource.MAGIC, damage);
 					}
 
-					target.motionX = dx;
-					target.motionY = velY + Spells.tornado.getProperty(Tornado.UPWARD_ACCELERATION).floatValue();
-					target.motionZ = dz;
-
-					// Player motion is handled on that player's client so needs packets
-					if(target instanceof EntityPlayerMP){
-						((EntityPlayerMP)target).connection.sendPacket(new SPacketEntityVelocity(target));
+					if(EntityUtils.canEntityBeMoved(this.getCaster(), target)) {
+						target.motionX = dx;
+						target.motionY = velY + Spells.tornado.getProperty(Tornado.UPWARD_ACCELERATION).floatValue();
+						target.motionZ = dz;
+						// Player motion is handled on that player's client so needs packets
+						if (target instanceof EntityPlayerMP) {
+							((EntityPlayerMP)target).connection.sendPacket(new SPacketEntityVelocity(target));
+						}
 					}
 				}
 			}
@@ -156,16 +148,14 @@ public class EntityTornado extends EntityScaledConstruct {
 						ResourceLocation type = null;
 
 						if(block.getMaterial() == Material.LEAVES) type = Type.LEAF;
-						if(block.getMaterial() == Material.SNOW || block.getMaterial() == Material.CRAFTED_SNOW)
-							type = Type.SNOW;
+						if(block.getMaterial() == Material.SNOW || block.getMaterial() == Material.CRAFTED_SNOW) type = Type.SNOW;
+
+						//If the tornado is burning, use fire particles because fire beats grass and ice
+						if(this.isBurning()) type = Type.MAGIC_FIRE;
 
 						if(type != null){
 							double yPos1 = rand.nextDouble() * 8;
-							ParticleBuilder.create(type)
-									.pos(this.posX + (rand.nextDouble() * 2 - 1) * (yPos1 / 3 + 0.5d), this.posY + yPos1,
-											this.posZ + (rand.nextDouble() * 2 - 1) * (yPos1 / 3 + 0.5d))
-									.time(40 + rand.nextInt(10))
-									.spawn(world);
+							ParticleBuilder.create(type).pos(this.posX + (rand.nextDouble() * 2 - 1) * (yPos1 / 3 + 0.5d), this.posY + yPos1, this.posZ + (rand.nextDouble() * 2 - 1) * (yPos1 / 3 + 0.5d)).time(40 + rand.nextInt(10)).spawn(world);
 						}
 					}
 				}

--- a/src/main/java/electroblob/wizardry/event/ArtefactCheckEvent.java
+++ b/src/main/java/electroblob/wizardry/event/ArtefactCheckEvent.java
@@ -2,44 +2,74 @@ package electroblob.wizardry.event;
 
 import electroblob.wizardry.item.ItemArtefact;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
-import net.minecraftforge.fml.common.eventhandler.Event;
+
+import java.util.List;
 
 /**
- * ArtefactCheckEvent is fired when a check happens for an ItemArtefact using {@link electroblob.wizardry.item.ItemArtefact#isArtefactActive(net.minecraft.entity.player.EntityPlayer, net.minecraft.item.Item)}
+ * ArtefactCheckEvent is fired when a check happens for an ItemArtefact using {@link ItemArtefact#isArtefactActive(EntityPlayer, Item)}
  * <i>Fired on both sides.</i><br>
- * <br>
- * This event is {@link Cancelable}. <br>
- * <br>
- * This event has a result. {@link HasResult}. Set the result to Result.ALLOW to consider an artefact "active"<br>
+ *  <br>
+ *  This event is {@link Cancelable}. <br>
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  *
- * @author WinDanesz
+ * @author ipdnaeip, adapted from WinDanesz
  * @since Wizardry 4.3.10
  */
 @Cancelable
-@Event.HasResult
 public class ArtefactCheckEvent extends PlayerEvent {
 
-	ItemArtefact artefact;
 	EntityPlayer player;
+	List<ItemArtefact.TrackedArtefact> artefacts;
 
-	public ArtefactCheckEvent(EntityPlayer player, ItemArtefact artefact) {
+	public ArtefactCheckEvent(EntityPlayer player, List<ItemArtefact.TrackedArtefact> artefacts) {
 		super(player);
 		this.player = player;
-		this.artefact = artefact;
-		setResult(Result.DENY);
-	}
-
-	public ItemArtefact getArtefact() {
-		return artefact;
+		this.artefacts = artefacts;
 	}
 
 	public EntityPlayer getPlayer() {
-		return player;
+		return this.player;
+	}
+
+	//Returns a modifiable list of active artefacts
+	public List<ItemArtefact.TrackedArtefact> getArtefacts() {
+		return this.artefacts;
+	}
+
+	//Adds an artefact maintaining the inventory and slot to allow for modifying of the ItemStack
+	public boolean addArtefact(ItemArtefact.TrackedArtefact slotItemStack) {
+		return artefacts.add(slotItemStack);
+	}
+
+	//Adds an unmodifiable artefact accounting for ItemStack properties
+	public boolean addArtefact(ItemStack itemStack) {
+		return this.addArtefact(new ItemArtefact.TrackedArtefact(itemStack));
+	}
+
+	//Adds ann unmodifiable artefact item
+	public boolean addArtefact(Item itemArtefact) {
+		return this.addArtefact(new ItemStack(itemArtefact));
+	}
+
+	//Removes all artefacts that match the SlotItemStack, could have a use if the player wants to deny artefacts from a certain inventory
+	public boolean removeArtefact(ItemArtefact.TrackedArtefact slotItemStack) {
+		return this.artefacts.removeIf(artefact -> artefact == slotItemStack);
+	}
+
+	//Removes all artefacts that match the ItemStack
+	public boolean removeArtefact(ItemStack itemStack) {
+		return this.artefacts.removeIf(artefact -> ItemStack.areItemStacksEqual(artefact.getItemStack(), itemStack));
+	}
+
+	//Removes all artefacts that match the Item
+	public boolean removeArtefact(Item itemArtefact) {
+		return this.artefacts.removeIf(artefact -> artefact.getItemStack().getItem() == itemArtefact);
 	}
 
 }

--- a/src/main/java/electroblob/wizardry/event/IsCastingEvent.java
+++ b/src/main/java/electroblob/wizardry/event/IsCastingEvent.java
@@ -1,0 +1,26 @@
+package electroblob.wizardry.event;
+
+import electroblob.wizardry.spell.Spell;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Allows for developers to hook into EntityUtils.isCasting to allow for custom spell casting effects to be considered as casting (for sound loops and other checks)
+ * Set the result to ALLOW to enable a casting effect
+ */
+@Event.HasResult
+public class IsCastingEvent extends LivingEvent {
+
+	private final Spell spell;
+
+	public IsCastingEvent(EntityLivingBase entity, Spell spell) {
+		super(entity);
+		this.spell = spell;
+	}
+
+	public Spell getSpell() {
+		return this.spell;
+	}
+
+}

--- a/src/main/java/electroblob/wizardry/integration/baubles/WizardryBaublesIntegration.java
+++ b/src/main/java/electroblob/wizardry/integration/baubles/WizardryBaublesIntegration.java
@@ -4,6 +4,7 @@ import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
 import baubles.api.IBauble;
 import baubles.api.cap.BaublesCapabilities;
+import baubles.api.cap.IBaublesItemHandler;
 import electroblob.wizardry.Wizardry;
 import electroblob.wizardry.item.ItemArtefact;
 import net.minecraft.entity.player.EntityPlayer;
@@ -88,6 +89,27 @@ public final class WizardryBaublesIntegration {
 		}
 
 		return artefacts;
+	}
+
+	public static List<ItemArtefact.TrackedArtefact> getEquippedTrackedArtefacts(EntityPlayer player, ItemArtefact.Type... types) {
+		List<ItemArtefact.TrackedArtefact> artefacts = new ArrayList<>();
+		IBaublesItemHandler handler = BaublesApi.getBaublesHandler(player);
+		for (ItemArtefact.Type type : types) {
+			for (int slot : ARTEFACT_TYPE_MAP.get(type).getValidSlots()) {
+				ItemStack stack = handler.getStackInSlot(slot);
+				if (stack.getItem() instanceof ItemArtefact) {
+					ItemArtefact itemArtefact = (ItemArtefact)stack.getItem();
+					if (itemArtefact.isEnabled() && itemArtefact.getType() == type) {
+						artefacts.add(new ItemArtefact.TrackedArtefact(stack, slot, handler));
+					}
+				}
+			}
+		}
+		return artefacts;
+	}
+
+	public static Map<ItemArtefact.Type, BaubleType> getArtefactTypeMap() {
+		return ARTEFACT_TYPE_MAP;
 	}
 
 	// Shamelessly copied from The Twilight Forest, with a few modifications

--- a/src/main/java/electroblob/wizardry/item/ItemArtefact.java
+++ b/src/main/java/electroblob/wizardry/item/ItemArtefact.java
@@ -25,6 +25,7 @@ import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -32,6 +33,7 @@ import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextFormatting;
@@ -53,6 +55,7 @@ import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -78,13 +81,6 @@ import java.util.stream.Collectors;
  */
 @Mod.EventBusSubscriber
 public class ItemArtefact extends Item {
-
-	// Artefact checklist:
-	// - Create and register item, add model and texture
-	// - Program effect, using events if possible (if it only affects a specific spell or entity, in there is ok)
-	// - Add name AND description to lang files
-	// - Add to loot_tables/subsets/[rarity]_artefacts.json
-	// - Add to advancements/artefact.json and advancements/all_artefacts.json
 
 	public enum Type {
 
@@ -157,11 +153,6 @@ public class ItemArtefact extends Item {
 		return WizardryBaublesIntegration.enabled() ? new WizardryBaublesIntegration.ArtefactBaubleProvider(type) : null;
 	}
 
-	// IBauble does of course have an onWornTick method. However, because it's an optional dependency, it doesn't really
-	// make sense to use that method when it's easier to just use the isBaubleEquipped method in the same
-	// place as the non-baubles check. In other words, most artefacts are event-driven anyway so I'd rather have the
-	// tick-driven ones use events as well for the sake of consistency.
-
 	/**
 	 * Returns whether the given artefact is active for the given player. If Baubles is loaded, an artefact is active
 	 * when it is equipped in an appropriate bauble slot. If Baubles is not loaded, an artefact is active if it is one
@@ -176,32 +167,35 @@ public class ItemArtefact extends Item {
 	 * item is not an instance of {@code ItemArtefact}.
 	 * @throws IllegalArgumentException If the given item is not an artefact.
 	 */
-	// It's cleaner to cast to ItemArtefact here than wherever it is used - items can't be stored as ItemWhatever objects
-	public static boolean isArtefactActive(EntityPlayer player, Item artefact){
-
-		if(!(artefact instanceof ItemArtefact)) throw new IllegalArgumentException("Not an artefact!");
-
-		if(!((ItemArtefact)artefact).enabled) return false; // Disabled in the config
-
-		ArtefactCheckEvent event = new ArtefactCheckEvent(player, (ItemArtefact) artefact);
-		if(MinecraftForge.EVENT_BUS.post(event)) return false;
-
-		if (event.getResult() == Event.Result.ALLOW) {
-			return true;
-		}
-
-		if(WizardryBaublesIntegration.enabled()){
-			return WizardryBaublesIntegration.isBaubleEquipped(player, artefact);
-		}else{
+	public static boolean isArtefactActive(EntityPlayer player, Item artefact) {
+		if (!(artefact instanceof ItemArtefact)) throw new IllegalArgumentException("Not an artefact!");
+		if (!((ItemArtefact)artefact).enabled) return false; // Disabled in the config
+		boolean equipped;
+		if (WizardryBaublesIntegration.enabled()) {
+			equipped = WizardryBaublesIntegration.isBaubleEquipped(player, artefact);
+		} else {
 			// To find out if the given artefact is one of the first n on the player's hotbar (where n is the maximum
 			// number of that kind of artefact that can be active at once):
-			return InventoryUtils.getPrioritisedHotbarAndOffhand(player).stream() // Retrieve the stacks in question
+			equipped = InventoryUtils.getPrioritisedHotbarAndOffhand(player).stream() // Retrieve the stacks in question
 					// Filter out all except artefacts of the same type as the given one (preserving order)
 					.filter(s -> s.getItem() instanceof ItemArtefact && ((ItemArtefact)s.getItem()).type == ((ItemArtefact)artefact).type)
 					.limit(((ItemArtefact)artefact).type.maxAtOnce)    // Ignore all but the first n
 					.anyMatch(s -> s.getItem() == artefact); // Check if the remaining stacks contain the artefact
 			// Note that streaming a list DOES retain the order (unless you call unordered(), obviously)
 		}
+		ArtefactCheckEvent event = new ArtefactCheckEvent(player, new ArrayList<>());
+		//Return false if the artefact was canceled
+		if (MinecraftForge.EVENT_BUS.post(event)) {
+			return false;
+		}
+		//Return true if there's at least one artefact that matches
+		for (TrackedArtefact trackedArtefact : event.getArtefacts()) {
+			if (trackedArtefact.itemStack.getItem() == artefact) {
+				equipped = true;
+				break;
+			}
+		}
+		return equipped;
 	}
 
 	/**
@@ -217,29 +211,114 @@ public class ItemArtefact extends Item {
 	 * item is not an instance of {@code ItemArtefact}.
 	 */
 	public static List<ItemArtefact> getActiveArtefacts(EntityPlayer player, Type... types){
-
-		if(types.length == 0) types = Type.values();
-
-		if(WizardryBaublesIntegration.enabled()){
-			List<ItemArtefact> artefacts = WizardryBaublesIntegration.getEquippedArtefacts(player, types);
-			artefacts.removeIf(i -> !i.enabled); // Remove artefacts that are disabled in the config
-			return artefacts;
-		}else{
-
-			List<ItemArtefact> artefacts = new ArrayList<>();
-
+		if (types.length == 0) types = Type.values();
+		List<ItemArtefact> artefacts;
+		if (WizardryBaublesIntegration.enabled()) {
+			artefacts = WizardryBaublesIntegration.getEquippedArtefacts(player, types);
+			artefacts.removeIf(i -> !i.isEnabled()); // Remove artefacts that are disabled in the config
+		} else {
+			artefacts = new ArrayList<>();
 			for(Type type : types){
 				artefacts.addAll(InventoryUtils.getPrioritisedHotbarAndOffhand(player).stream()
 						.filter(s -> s.getItem() instanceof ItemArtefact)
 						.map(s -> (ItemArtefact)s.getItem())
-						.filter(i -> type == i.type && i.enabled)
+						.filter(i -> type == i.getType() && i.isEnabled())
 						.limit(type.maxAtOnce)
 						.collect(Collectors.toList()));
 			}
-
-			return artefacts;
 		}
+		List<TrackedArtefact> slotItemStacks = new ArrayList<>();
+		//Add the active artefacts as SlotItemStacks so that they can be evaluated by the event
+		for (ItemArtefact artefact : artefacts) {
+			slotItemStacks.add(new TrackedArtefact(new ItemStack(artefact)));
+		}
+		ArtefactCheckEvent event = new ArtefactCheckEvent(player, slotItemStacks);
+		//Return an empty list if the event is canceled
+		if (MinecraftForge.EVENT_BUS.post(event)) {
+			return new ArrayList<>();
+		}
+		//Empty the list and add the items of the event artefacts
+		artefacts.clear();
+		for (TrackedArtefact trackedArtefact : slotItemStacks) {
+			Item item = trackedArtefact.itemStack.getItem();
+			if (item instanceof ItemArtefact) {
+				artefacts.add((ItemArtefact)item);
+			}
+		}
+		return artefacts;
 	}
+
+	public static List<TrackedArtefact> getActiveTrackedArtefacts(EntityPlayer player, Type... types) {
+		if (types.length == 0) {
+			types = Type.values();
+		}
+		List<TrackedArtefact> artefacts = new ArrayList<>();
+		if (WizardryBaublesIntegration.enabled()) {
+			artefacts = WizardryBaublesIntegration.getEquippedTrackedArtefacts(player, types);
+		} else {
+			List<TrackedArtefact> possibleArtefacts = new ArrayList<>();
+			int slot = 0;
+			NonNullList<ItemStack> mainInventory = player.inventory.mainInventory;
+			while (slot < 9) {
+				possibleArtefacts.add(new TrackedArtefact(mainInventory.get(slot), slot, player.inventory));
+				slot++;
+			}
+			possibleArtefacts.add(0, new TrackedArtefact(player.getHeldItemOffhand(), 0, player.inventory.offHandInventory));
+			possibleArtefacts.removeIf(trackedArtefact -> trackedArtefact.getItemStack() == player.getHeldItemMainhand());
+			possibleArtefacts.add(0, new TrackedArtefact(player.getHeldItemOffhand(), 0, player.inventory.mainInventory));
+			for (TrackedArtefact possibleArtefact : possibleArtefacts) {
+				for (Type type : types) {
+					int max = 0;
+					if (possibleArtefact.getItemStack().getItem() instanceof ItemArtefact) {
+						ItemStack itemStack = possibleArtefact.getItemStack();
+						while (max < type.maxAtOnce) {
+							ItemArtefact itemArtefact = (ItemArtefact)itemStack.getItem();
+							if (itemArtefact.isEnabled() && itemArtefact.getType() == type) {
+								artefacts.add(possibleArtefact);
+							}
+							max++;
+						}
+					}
+				}
+			}
+		}
+		//Event injection
+		ArtefactCheckEvent event = new ArtefactCheckEvent(player, artefacts);
+		if (MinecraftForge.EVENT_BUS.post(event)) {
+			return new ArrayList<>();
+		}
+		return artefacts;
+	}
+
+	//Use this to safely modify equipped artefacts with getActiveTrackedArtefacts
+	//Returns a boolean to enable effects only if the artefact is modified
+	public static boolean modifyArtefact(TrackedArtefact artefact) {
+		if (artefact.isModifiable()) {
+			if (artefact.getInventory() instanceof IInventory) {
+				if (artefact.getSlot() < ((IInventory)artefact.getInventory()).getSizeInventory()) {
+					((IInventory)artefact.getInventory()).setInventorySlotContents(artefact.getSlot(), artefact.getItemStack());
+					return true;
+				} else {
+					throw new IllegalArgumentException("Slot is outside the the inventory bounds!");
+				}
+			} else if (artefact.getInventory() instanceof IItemHandlerModifiable) {
+				if (artefact.getSlot() >= 0 && artefact.getSlot() < ((IItemHandlerModifiable)artefact.getInventory()).getSlots()) {
+					((IItemHandlerModifiable)artefact.getInventory()).setStackInSlot(artefact.getSlot(), artefact.getItemStack());
+					return true;
+				} else {
+					throw new IllegalArgumentException("Slot is outside the the inventory bounds!");
+				}
+			} else {
+				throw new IllegalArgumentException("Inventory must be of type IInventory or IItemHandlerModifiable into order to modify!");
+			}
+		}
+		return false;
+	}
+
+	// IBauble does of course have an onWornTick method. However, because it's an optional dependency, it doesn't really
+	// make sense to use that method when it's easier to just use the isBaubleEquipped method in the same
+	// place as the non-baubles check. In other words, most artefacts are event-driven anyway so I'd rather have the
+	// tick-driven ones use events as well for the sake of consistency.
 
 	/**
 	 * Helper method that scans through all wands on the given player's hotbar and offhand and executes the given action
@@ -946,6 +1025,49 @@ public class ItemArtefact extends Item {
 				findMatchingWandAndCast(event.player, Spells.pocket_furnace);
 			}
 		}
+	}
+
+	public static final class TrackedArtefact {
+
+		private final ItemStack itemStack;
+		//Set to -1 to disable modification
+		private final int slot;
+		@Nullable
+		private final Object inventory;
+
+		public TrackedArtefact(ItemStack itemStack, int slot, @Nullable Object inventory) {
+			if (itemStack == null) {
+				//Cant be null!
+				this.itemStack = ItemStack.EMPTY;
+			} else {
+				//Make the ItemStack a copy so you cant modify it
+				this.itemStack = itemStack.copy();
+			}
+			this.slot = slot;
+			this.inventory = inventory;
+		}
+
+		public TrackedArtefact(ItemStack itemStack) {
+			this(itemStack, -1, null);
+		}
+
+		public ItemStack getItemStack() {
+			return this.itemStack;
+		}
+
+		public int getSlot() {
+			return this.slot;
+		}
+
+		@Nullable
+		public Object getInventory() {
+			return this.inventory;
+		}
+
+		public boolean isModifiable() {
+			return this.slot >= 0;
+		}
+
 	}
 
 }

--- a/src/main/java/electroblob/wizardry/spell/GreaterTelekinesis.java
+++ b/src/main/java/electroblob/wizardry/spell/GreaterTelekinesis.java
@@ -69,8 +69,7 @@ public class GreaterTelekinesis extends SpellRay {
 		// Can't be cast by dispensers so we know caster isn't null, but just in case...
 		if(caster != null && (target instanceof EntityLivingBase || target instanceof EntityLevitatingBlock || target instanceof EntityTNTPrimed)){
 
-			if(target instanceof EntityPlayer && ((caster instanceof EntityPlayer && !Wizardry.settings.playersMoveEachOther)
-					|| ItemArtefact.isArtefactActive((EntityPlayer)target, WizardryItems.amulet_anchoring))){
+			if(!EntityUtils.canEntityBeMoved(caster, target)){
 
 				if(!world.isRemote && caster instanceof EntityPlayer) ((EntityPlayer)caster).sendStatusMessage(
 						new TextComponentTranslation("spell.resist", target.getName(), this.getNameForTranslationFormatted()), true);

--- a/src/main/java/electroblob/wizardry/spell/Levitation.java
+++ b/src/main/java/electroblob/wizardry/spell/Levitation.java
@@ -40,10 +40,23 @@ public class Levitation extends Spell {
 	@Override
 	public boolean cast(World world, EntityPlayer caster, EnumHand hand, int ticksInUse, SpellModifiers modifiers){
 
-		if(!Wizardry.settings.replaceVanillaFallDamage) caster.fallDistance = 0;
+		double prevMotionY = caster.motionY;
 
-		caster.motionY = caster.motionY < getProperty(SPEED).floatValue() ? caster.motionY
-				+ getProperty(ACCELERATION).floatValue() : caster.motionY;
+		float potency = modifiers.get(SpellModifiers.POTENCY);
+		float upwardVelocity = this.getProperty(SPEED).floatValue() * potency;
+		//Needs to be greater than 0.08 to counteract gravity
+		float upwardAcceleration = this.getProperty(ACCELERATION).floatValue() * potency;
+
+		//Change to min check to avoid jittery screen effects at high acceleration
+		caster.motionY = Math.min(caster.motionY + upwardAcceleration, upwardVelocity);
+
+		if (!Wizardry.settings.replaceVanillaFallDamage) {
+			if (caster.motionY < 0 && caster.motionY > prevMotionY) {
+				caster.fallDistance *= (float)(caster.motionY / prevMotionY);
+			} else if (caster.motionY >= 0) {
+				caster.fallDistance = 0;
+			}
+		}
 
 		if(world.isRemote){
 			double x = caster.posX - 0.25 + world.rand.nextDouble() * 0.5;

--- a/src/main/java/electroblob/wizardry/spell/Paralysis.java
+++ b/src/main/java/electroblob/wizardry/spell/Paralysis.java
@@ -1,5 +1,6 @@
 package electroblob.wizardry.spell;
 
+import electroblob.wizardry.data.WizardData;
 import electroblob.wizardry.item.SpellActions;
 import electroblob.wizardry.registry.Spells;
 import electroblob.wizardry.registry.WizardryItems;
@@ -19,6 +20,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.PotionEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -103,7 +105,7 @@ public class Paralysis extends SpellRay {
 	
 	// See WizardryClientEventHandler for prevention of players' movement under the effects of paralysis
 	
-	@SubscribeEvent
+/*	@SubscribeEvent
 	public static void onLivingUpdateEvent(LivingUpdateEvent event){
 		// Disables entities' AI when under the effects of paralysis and re-enables it on the last update of the effect
 		// - this can't be in the potion class because it requires access to the duration and hence the actual
@@ -112,7 +114,7 @@ public class Paralysis extends SpellRay {
 			int timeLeft = event.getEntityLiving().getActivePotionEffect(WizardryPotions.paralysis).getDuration();
 			((EntityLiving)event.getEntity()).setNoAI(timeLeft > 1);
 		}
-	}
+	}*/
 	
 	@SubscribeEvent
 	public static void onLivingHurtEvent(LivingHurtEvent event){
@@ -120,6 +122,37 @@ public class Paralysis extends SpellRay {
 		if(event.getEntityLiving().isPotionActive(WizardryPotions.paralysis) && event.getEntityLiving().getHealth()
 				- event.getAmount() <= Spells.paralysis.getProperty(CRITICAL_HEALTH).floatValue()){
 			event.getEntityLiving().removePotionEffect(WizardryPotions.paralysis);
+		}
+	}
+
+	@SubscribeEvent
+	public static void onPotionAddedEvent(PotionEvent.PotionAddedEvent event) {
+		if (event.getEntityLiving() instanceof EntityPlayer) {
+			EntityPlayer player = (EntityPlayer)event.getEntityLiving();
+			WizardData data = WizardData.get(player);
+			if (data != null) {
+				data.paralyzedRotationPitch = player.rotationPitch;
+				data.paralyzedRotationYaw = player.rotationYaw;
+			}
+		// Disables entity's AI when affected by paralysis
+		} else if (event.getEntityLiving() instanceof EntityLiving) {
+			((EntityLiving)event.getEntityLiving()).setNoAI(true);
+		}
+	}
+
+	@SubscribeEvent
+	public static void onPotionExpiryEvent(PotionEvent.PotionExpiryEvent event) {
+		if (event.getEntityLiving() instanceof EntityLiving) {
+			//Enables the entity's AI when paralysis expires
+			((EntityLiving)event.getEntityLiving()).setNoAI(false);
+		}
+	}
+
+	@SubscribeEvent
+	public static void onPotionRemoveEvent(PotionEvent.PotionRemoveEvent event) {
+		if (event.getEntityLiving() instanceof EntityLiving) {
+			//Enables the entity's AI when paralysis is removed
+			((EntityLiving)event.getEntityLiving()).setNoAI(false);
 		}
 	}
 

--- a/src/main/java/electroblob/wizardry/spell/Shockwave.java
+++ b/src/main/java/electroblob/wizardry/spell/Shockwave.java
@@ -42,16 +42,9 @@ public class Shockwave extends SpellAreaEffect {
 
 		float radius = getProperty(EFFECT_RADIUS).floatValue() * modifiers.get(WizardryItems.blast_upgrade);
 
-		if(target instanceof EntityPlayer){
-
-			if(!Wizardry.settings.playersMoveEachOther) return false;
-
-			if(ItemArtefact.isArtefactActive((EntityPlayer)target, WizardryItems.amulet_anchoring)){
-				if(!world.isRemote && caster instanceof EntityPlayer) ((EntityPlayer)caster).sendStatusMessage(
-						new TextComponentTranslation("spell.resist", target.getName(),
-								this.getNameForTranslationFormatted()), true);
-				return false;
-			}
+		if (!EntityUtils.canEntityBeMoved(caster, target)) {
+			if(!world.isRemote && caster instanceof EntityPlayer) ((EntityPlayer)caster).sendStatusMessage(new TextComponentTranslation("spell.resist", target.getName(), this.getNameForTranslationFormatted()), true);
+			return false;
 		}
 
 		// Produces a linear profile from 0 at the edge of the radius to 1 at the epicentre radius, then

--- a/src/main/java/electroblob/wizardry/spell/Whirlwind.java
+++ b/src/main/java/electroblob/wizardry/spell/Whirlwind.java
@@ -4,6 +4,7 @@ import electroblob.wizardry.Wizardry;
 import electroblob.wizardry.item.ItemArtefact;
 import electroblob.wizardry.item.SpellActions;
 import electroblob.wizardry.registry.WizardryItems;
+import electroblob.wizardry.util.EntityUtils;
 import electroblob.wizardry.util.SpellModifiers;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -30,11 +31,8 @@ public class Whirlwind extends SpellRay {
 	@Override
 	protected boolean onEntityHit(World world, Entity target, Vec3d hit, EntityLivingBase caster, Vec3d origin, int ticksInUse, SpellModifiers modifiers){
 
-		if(target instanceof EntityPlayer && ((caster instanceof EntityPlayer && !Wizardry.settings.playersMoveEachOther)
-				|| ItemArtefact.isArtefactActive((EntityPlayer)target, WizardryItems.amulet_anchoring))){
-
-			if(!world.isRemote && caster instanceof EntityPlayer) ((EntityPlayer)caster).sendStatusMessage(
-					new TextComponentTranslation("spell.resist", target.getName(), this.getNameForTranslationFormatted()), true);
+		if (!EntityUtils.canEntityBeMoved(caster, target)) {
+			if(!world.isRemote && caster instanceof EntityPlayer) ((EntityPlayer)caster).sendStatusMessage(new TextComponentTranslation("spell.resist", target.getName(), this.getNameForTranslationFormatted()), true);
 			return false;
 		}
 

--- a/src/main/java/electroblob/wizardry/util/EntityUtils.java
+++ b/src/main/java/electroblob/wizardry/util/EntityUtils.java
@@ -4,7 +4,10 @@ import com.google.common.collect.Streams;
 import electroblob.wizardry.Wizardry;
 import electroblob.wizardry.data.WizardData;
 import electroblob.wizardry.entity.living.ISpellCaster;
+import electroblob.wizardry.event.IsCastingEvent;
 import electroblob.wizardry.item.ISpellCastingItem;
+import electroblob.wizardry.item.ItemArtefact;
+import electroblob.wizardry.registry.WizardryItems;
 import electroblob.wizardry.spell.Spell;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -29,6 +32,7 @@ import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.eventhandler.Event;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
@@ -426,6 +430,12 @@ public final class EntityUtils {
 
 		if(!spell.isContinuous) return false;
 
+		IsCastingEvent event = new IsCastingEvent(caster, spell);
+		//Only need to check if it is allowed
+		if (event.getResult() == Event.Result.ALLOW) {
+			return true;
+		}
+
 		if(caster instanceof EntityPlayer){
 
 			WizardData data = WizardData.get((EntityPlayer)caster);
@@ -494,6 +504,17 @@ public final class EntityUtils {
 	 */
 	public static void playSoundAtPlayer(EntityPlayer player, SoundEvent sound, float volume, float pitch){
 		player.world.playSound(null, player.posX, player.posY, player.posZ, sound, SoundCategory.PLAYERS, volume, pitch);
+	}
+
+	public static boolean canEntityBeMoved(@Nullable Entity mover, Entity target) {
+		if (target instanceof EntityPlayer) {
+			if (mover instanceof EntityPlayer && !Wizardry.settings.playersMoveEachOther) {
+				return false;
+			} else if (ItemArtefact.isArtefactActive((EntityPlayer)target, WizardryItems.amulet_anchoring)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 }

--- a/src/main/resources/assets/ebwizardry/spells/levitation.json
+++ b/src/main/resources/assets/ebwizardry/spells/levitation.json
@@ -17,7 +17,7 @@
   "chargeup": 0,
   "cooldown": 0,
   "base_properties": {
-    "speed": 0.5,
+    "speed": 0.3,
     "acceleration": 0.1
   }
 }


### PR DESCRIPTION
Added WizardryBaublesIntegration.getEquippedTrackedArtefacts to return a list of ItemArtefact.TrackedArtefacts, which track the inventory and slot of artefacts

Made ARTEFACT_TYPE_MAP publicly accessible for addon creators (me)

Changed ArtefactCheckEvent to work with TrackedArtefacts

Modified existing artefact check methods to work with ArtefactCheckEvent

Added new method ItemArtefact.getActiveTrackedArtefacts to allow addon creators to modify artefacts using ItemArtefact.modifyArtefact

Only TrackedArtefacts with an inventory and slot can be modified